### PR TITLE
Adds the ability to cross check ownership with the DLC catalog.

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -132,6 +132,7 @@
 	"forceGenerateView": "Force Generate VIew",
 	"updateSongsOwned": "Update Songs &gt; Owned",
 	"markAllAsCDLC": "Mark All as CDLC",
+	"ownedCheck": "DLC Owned Check",
 	"File Name": "File Name",
 	"Size": "Size",
 	"Created At": "Created At",

--- a/src/Components/psarcView.js
+++ b/src/Components/psarcView.js
@@ -202,7 +202,8 @@ class PSARCView extends React.Component {
   }
 
   updateSongList = async () => {
-    profileWorker.songListUpdate(this.state.files, this.markAsCDLC.checked);
+    const catalog = this.dlcCatalogOwnedCheck.checked;
+    profileWorker.songListUpdate(this.state.files, this.markAsCDLC.checked, catalog);
   }
 
   render = () => {
@@ -250,6 +251,21 @@ class PSARCView extends React.Component {
               id="cdlc"
               name="cdlc"
               value="cdlc"
+            />
+          </span>
+          <span style={{ display: `${hasdatastyle}` }}>
+            <label htmlFor="ownedCheck">
+              <Trans i18nKey="dlcCatalogOwnedCheck">
+                DLC Owned Check
+            </Trans>
+            </label>
+            <input
+              ref={(node) => { this.dlcCatalogOwnedCheck = node }}
+              style={{ margin: 7 + 'px' }}
+              type="checkbox"
+              id="ownedCheck"
+              name="ownedCheck"
+              value="ownedCheck"
             />
           </span>
         </div>

--- a/src/sqliteService.js
+++ b/src/sqliteService.js
@@ -737,6 +737,11 @@ export async function updateSongsOwnedV2(songs, isCDLC = false) {
   }
   return changes;
 }
+export async function ownedCatalogSongNames() {
+  const ownedSql = "SELECT name FROM songs_available WHERE owned = 'true';"
+  const ownedRows = await db.all(ownedSql);
+  return ownedRows.map((row) => { return row.name; });
+}
 export async function removeIgnoredArrangements() {
   const sql = "DELETE from songs_owned where id in (select id from ignored_arrangements);"
   const op = await db.run(sql);


### PR DESCRIPTION
This works around an issue I found with the RS1 Compatibility DLC. The RS1 DLC includes all of the songs that are available for purchase (whether or not you've actually bought them). When importing "rs1compatibilitydlc_m.psarc" you end up with a bunch of songs included in your playlists that you can't actually play.

The workaround is to make sure your DLC catalog is up to date and then cross checked the owned names there. In theory this could be used to ignore your CLDC items if you didn't want them imported (though I doubt that is generally a problem).

Honestly, the added checkbox further polutes the import screen, so I'm not 100% sure this is the cleanest way to approach this problem. Feedback welcome here.

One issue: You have to visit the Catalog once before running the import. Is there a way to force that page to be up to date?